### PR TITLE
fix(admin): hoist setupNavigation above iframe-load effect; const-ify…

### DIFF
--- a/src/components/admin/stitch-page-renderer.tsx
+++ b/src/components/admin/stitch-page-renderer.tsx
@@ -716,26 +716,6 @@ export function StitchPageRenderer({ routeKey }: StitchPageRendererProps) {
     void loadSectionContent(activeRouteKey)
   }, [activeRouteKey, shellReady])
 
-  // Personalize iframe after it loads.
-  useEffect(() => {
-    const iframe = iframeRef.current
-    if (!iframe) return
-
-    const handleIframeLoad = async () => {
-      setShellReady(true)
-      personalizeIframe()
-      setupNavigation()
-      syncSidebarActiveState(activeRouteKey)
-      await loadSectionContent(activeRouteKey)
-    }
-
-    iframe.addEventListener('load', handleIframeLoad)
-
-    return () => {
-      iframe.removeEventListener('load', handleIframeLoad)
-    }
-  }, [userData])
-
   const setupNavigation = () => {
     const iframe = iframeRef.current
     if (!iframe) return
@@ -762,10 +742,30 @@ export function StitchPageRenderer({ routeKey }: StitchPageRendererProps) {
           }
         }
       })
-    } catch (err) {
+    } catch {
       console.log('Cannot access iframe content (cross-origin)')
     }
   }
+
+  // Personalize iframe after it loads.
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+
+    const handleIframeLoad = async () => {
+      setShellReady(true)
+      personalizeIframe()
+      setupNavigation()
+      syncSidebarActiveState(activeRouteKey)
+      await loadSectionContent(activeRouteKey)
+    }
+
+    iframe.addEventListener('load', handleIframeLoad)
+
+    return () => {
+      iframe.removeEventListener('load', handleIframeLoad)
+    }
+  }, [userData])
 
   return (
     <iframe

--- a/src/lib/pdf/generate-pdf.ts
+++ b/src/lib/pdf/generate-pdf.ts
@@ -50,7 +50,7 @@ export function generateRevenueReport(data: {
 
   doc.setFontSize(11)
   doc.setTextColor(0, 0, 0)
-  let y = 75
+  const y = 75
 
   const summaryData = [
     ['Total Revenue', `$${data.totalRevenue.toFixed(2)}`],


### PR DESCRIPTION
… pdf y

Two ESLint-evidenced fixes:

1. src/components/admin/stitch-page-renderer.tsx
   - The iframe `load` handler called `setupNavigation()` while the const was declared further down in the component, triggering ESLint's `react-hooks/immutability` ("accessed before declared") error and creating a stale-closure footgun across re-renders.
   - Move the `setupNavigation` declaration above the useEffect that references it. Also drop an unused `(err)` binding in the catch block (no behaviour change).

2. src/lib/pdf/generate-pdf.ts
   - `let y = 75` in `generateRevenueReport` is never reassigned; change to `const y = 75` to satisfy `prefer-const` and reflect intent (other `let y` in the file IS reassigned and is left alone).

Verified locally:
  - `npx next build` -> Compiled successfully, 46/46 routes prerendered
  - `npx eslint` on the two files -> the two targeted errors are gone