### PR TITLE
feat: customer corrections (Jun 2026)

### DIFF
--- a/docs/PR-jun2026-customer-corrections.md
+++ b/docs/PR-jun2026-customer-corrections.md
@@ -1,0 +1,61 @@
+# PR: Customer corrections — June 2026 (Madison Condurso email)
+
+Implements the "Corrections to Mainstream Back End" list from the client.
+Branch: `feat/customer-corrections-jun2026` → base `feat/sfms-implementation-plan-v3`.
+
+## ⚠️ Run these migrations before/at deploy (in order)
+
+These features need DB changes. Run in the Supabase SQL editor in numeric order:
+
+- `supabase/migrations/00019_machines_description_image_delete.sql`
+  — adds `machines.description`, `machines.image_url`, and a DELETE policy for managers/owners.
+- `supabase/migrations/00020_token_transactions_edit_delete.sql`
+  — adds UPDATE + DELETE policies on `token_transactions` for managers/owners.
+- `supabase/migrations/00021_storage_media_bucket.sql`
+  — creates the public `media` storage bucket + policies for prize/machine images.
+
+All three are idempotent (safe to re-run). The frontend compiles without them,
+but the new buttons will error at runtime until they're applied.
+
+## Fixed
+
+- **Prize Inventory — edit price.** New **Edit** dialog on each prize: name,
+  description, **ticket cost (price)**, category, reorder threshold, active, and
+  picture. (Stock keeps its existing quick-edit button.)
+- **Remove the token percentage add.** Token pricing is now flat **3 tokens per
+  $1** (`$20 = 60`, was 66 "10% savings"). Removed the "+6 Bonus Tokens" /
+  "savings" labels from the live home and pricing pages. Seasonal deals (e.g.
+  "$100 gets $10 free") are meant to run through **coupons** so they can be
+  toggled on/off — no code change needed to switch a deal on/off.
+- **Machines — edit description + delete.** New **Edit** dialog (incl. a
+  description field) and a **Delete** action (with confirm) for machines no
+  longer inventoried.
+- **Email requests — view full message.** The inquiries inbox previously never
+  showed the message body. Added a **View** dialog with the full message,
+  sender, topic, timestamp, a "Reply by email" link, and auto-marks new
+  inquiries as read.
+- **Party Bookings — view full message.** Added a **View** dialog showing the
+  full `special requests` message plus contact email, guest counts, deposit, and
+  totals.
+
+## Added
+
+- **Prize Inventory — picture per product.** Upload/replace/remove an image;
+  shown on the prize card (and already surfaced on the customer prizes page).
+- **Machines — picture slotted.** Same upload control; shown on the machine card.
+- **Delete / edit token purchases after processing.** Token transaction log now
+  has per-row **Edit** (amount, tokens, payment type) and **Delete** (with
+  confirm); revenue stats refresh automatically. Owner/manager only.
+
+## Implementation notes
+
+- Images upload to a single public Supabase Storage bucket `media`
+  (`media/prizes/…`, `media/machines/…`) via a shared
+  `ImageUploadField` component and `src/lib/storage.ts` helper. Public read so
+  `<img src>` works without signed URLs; uploads restricted to staff by RLS.
+- Permissions reuse the existing SECURITY DEFINER helpers
+  (`is_staff()`, `is_manager_or_owner()`) from migration `00016`.
+- Typecheck passes (`tsc --noEmit`, exit 0). No dependencies added.
+
+See `docs/SUPABASE-TRANSFER.md` for moving the project from the personal
+Supabase account to the business account (separate from this PR).

--- a/docs/SUPABASE-TRANSFER.md
+++ b/docs/SUPABASE-TRANSFER.md
@@ -1,0 +1,88 @@
+# Moving Supabase from a personal account to the Smile Factory business account
+
+**Short answer: yes — this can be done with zero code changes and ~no downtime.**
+Supabase has a built-in **Project Transfer** that moves a project from one
+organization to another *without recreating it*. Because the project keeps the
+same project ref (`tatstgyphzkambjacbvl`), everything the app depends on stays
+identical:
+
+- Same API URL (`NEXT_PUBLIC_SUPABASE_URL`)
+- Same anon/service keys (`NEXT_PUBLIC_SUPABASE_ANON_KEY`, etc.)
+- Same JWT secret → **logged-in customers stay logged in**
+- Same schema, RLS policies, data, storage buckets
+
+So **no `.env` changes, no Vercel env changes, no redeploy** are required. This
+is the safe path and the one to use.
+
+---
+
+## Recommended path — Project Transfer (non-destructive)
+
+1. **Create the business organization** in Supabase
+   (Dashboard → top-left org switcher → *New organization*). Put it on the
+   **Pro plan** if the project is currently Pro, so no paid features are lost in
+   the move (see caveats below).
+2. **Add the business owner** (and yourself) as members of the new org with the
+   **Owner** role.
+3. Clear the transfer blockers on the current project (see *Pre-requirements*).
+4. Go to the project's **General settings**
+   (Dashboard → Project → *Settings → General*) → **Transfer project**.
+5. Pick the **business org** as the target and confirm.
+6. Done. The app keeps running against the same URL/keys.
+
+### Pre-requirements (Supabase enforces these)
+
+- You must be the **Owner of the source organization** (your personal one).
+- You must be at least a **member of the target** (business) org.
+- **No active GitHub integration** connection on the project — disconnect it
+  first if one exists (this is Supabase's GitHub/branching integration, *not*
+  your Vercel→GitHub deploy, which is unaffected).
+- **No project-scoped roles** pointing at the project (Team/Enterprise only).
+- **No log drains** configured.
+
+### Caveats to watch
+
+- Moving from a **paid plan to the Free plan** can cause a **1–2 minute
+  downtime** and may disable paid features. Moving **paid → paid** is
+  effectively zero downtime. → If the business org will be Free, weigh that;
+  otherwise **upgrade the target org to Pro before transferring**.
+- Free orgs are limited to **2 free projects** — make room first if relevant.
+- A transfer **cannot change the project's region**. (Not needed here.)
+- Usage billed before the transfer lands on the personal org's final invoice;
+  usage after lands on the business org.
+
+---
+
+## Fallback path — Restore to a new project (only if transfer is blocked)
+
+Use this **only** if a transfer blocker can't be cleared. This **does** change
+the URL and keys, so it requires an env update + redeploy and a short cutover.
+
+1. In the business org, create a **new project** (same region).
+2. Migrate schema + data (Supabase Dashboard has a *Restore to a new project*
+   flow, or use the CLI):
+   ```bash
+   supabase db dump --project-ref tatstgyphzkambjacbvl --schema-only > schema.sql
+   supabase db dump --project-ref tatstgyphzkambjacbvl --data-only   > data.sql
+   psql "$NEW_PROJECT_DB_URL" -f schema.sql
+   psql "$NEW_PROJECT_DB_URL" -f data.sql
+   ```
+3. **Re-upload Storage objects** (prize/machine images live in the `media`
+   bucket) — the CLI `supabase storage cp` helps here.
+4. To avoid logging every customer out, **reuse the original project's JWT
+   secret** in the new project (Auth settings). Different JWT secret = all
+   existing sessions invalidated.
+5. Update `NEXT_PUBLIC_SUPABASE_URL` and the keys in `.env.local` **and** in
+   Vercel, then redeploy.
+
+---
+
+## Bottom line
+
+Prefer the **Project Transfer**. It's the option that does *not* break the
+backend or require touching the deployed app — keys, URL, and sessions are all
+preserved. Keep the personal account around until you've confirmed the business
+org shows the project and the live site still works.
+
+> Sources: [Supabase — Project Transfers](https://supabase.com/docs/guides/platform/project-transfer) ·
+> [Supabase — Migrating within Supabase](https://supabase.com/docs/guides/platform/migrating-within-supabase)

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -221,9 +221,6 @@ export default function HomePage() {
                   <span className="text-2xl font-black uppercase tracking-tight font-display">
                     {tier.tokens} Tokens
                   </span>
-                  {tier.price === 20 && (
-                    <p className="text-sm text-primary font-black mt-3 italic">+6 Bonus Tokens!</p>
-                  )}
                   <BuyTokensRedirectButton
                     className={`mt-8 w-full py-4 rounded-xl font-black uppercase tracking-widest text-sm transition-all shadow-sm ${
                       isBestValue

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -83,14 +83,9 @@ export default function PricingPage() {
                     {tierNames[i]}
                   </span>
                   <div className="text-6xl font-display font-black mb-2">${tier.price}</div>
-                  <div className="text-2xl font-display font-bold text-primary mb-2 italic">
+                  <div className="text-2xl font-display font-bold text-primary mb-4 italic">
                     {tier.tokens} TOKENS
                   </div>
-                  {tier.price === 20 && (
-                    <div className="text-primary font-bold text-[10px] mb-4 uppercase tracking-wider italic">
-                      +6 Bonus Tokens Included
-                    </div>
-                  )}
                   <BuyTokensRedirectButton
                     className={`mt-auto w-full py-4 rounded-xl font-display font-bold uppercase tracking-widest text-xs transition-all ${
                       isPopular

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -12,6 +12,13 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -69,6 +76,7 @@ export default function AdminBookingsPage() {
   const [loading, setLoading] = useState(true)
   const [statusFilter, setStatusFilter] = useState<'all' | BookingStatus>('all')
   const [updatingId, setUpdatingId] = useState<string | null>(null)
+  const [detailTarget, setDetailTarget] = useState<PartyBooking | null>(null)
 
   const canManageBookings = isManager()
 
@@ -317,6 +325,9 @@ export default function AdminBookingsPage() {
                     <TableHead className="text-right font-display font-semibold tracking-tight">
                       Total
                     </TableHead>
+                    <TableHead className="text-right font-display font-semibold tracking-tight">
+                      Details
+                    </TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -388,6 +399,17 @@ export default function AdminBookingsPage() {
                       <TableCell className="text-right font-medium tabular-nums">
                         {currency(toNumber(b.total_amount))}
                       </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          className="rounded-xl"
+                          onClick={() => setDetailTarget(b)}
+                        >
+                          View
+                        </Button>
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -402,6 +424,86 @@ export default function AdminBookingsPage() {
           Status changes are limited to owners and managers.
         </p>
       )}
+
+      <Dialog
+        open={!!detailTarget}
+        onOpenChange={(open) => {
+          if (!open) setDetailTarget(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="font-display text-xl font-black tracking-tight">
+              {detailTarget?.contact_name}
+            </DialogTitle>
+            <DialogDescription>
+              {detailTarget
+                ? `${safeFormatDate(detailTarget.booking_date, 'EEEE, MMM d, yyyy')} · ${formatTime(
+                    detailTarget.start_time
+                  )}–${formatTime(detailTarget.end_time)}`
+                : ''}
+            </DialogDescription>
+          </DialogHeader>
+          {detailTarget && (
+            <div className="space-y-4 text-sm">
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-3">
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Phone
+                  </dt>
+                  <dd className="font-medium">{detailTarget.contact_phone}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Email
+                  </dt>
+                  <dd className="font-medium break-all">{detailTarget.contact_email}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Guests
+                  </dt>
+                  <dd className="font-medium">
+                    {detailTarget.num_kids} kids · {detailTarget.num_adults} adults
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Status
+                  </dt>
+                  <dd className="font-medium capitalize">{detailTarget.status}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Deposit
+                  </dt>
+                  <dd className="font-medium">
+                    {currency(toNumber(detailTarget.deposit_amount))}{' '}
+                    {detailTarget.deposit_paid ? '(paid' : '(unpaid'}
+                    {detailTarget.deposit_method ? ` · ${detailTarget.deposit_method})` : ')'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Total
+                  </dt>
+                  <dd className="font-medium">{currency(toNumber(detailTarget.total_amount))}</dd>
+                </div>
+              </dl>
+              <div>
+                <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Special requests / message
+                </p>
+                <div className="max-h-[40vh] overflow-y-auto whitespace-pre-wrap rounded-xl border border-gray-100 bg-gray-50/80 p-4 leading-relaxed">
+                  {detailTarget.special_requests?.trim()
+                    ? detailTarget.special_requests
+                    : 'No special requests provided.'}
+                </div>
+              </div>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/app/admin/inquiries/page.tsx
+++ b/src/app/admin/inquiries/page.tsx
@@ -8,6 +8,14 @@ import { Button } from '@/components/ui/button'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 
 type Row = {
   id: string
@@ -23,6 +31,7 @@ export default function AdminInquiriesPage() {
   const sb = createClient()
   const [rows, setRows] = useState<Row[]>([])
   const [filter, setFilter] = useState<'all' | 'new' | 'read' | 'resolved'>('all')
+  const [viewTarget, setViewTarget] = useState<Row | null>(null)
 
   useEffect(() => {
     sb.from('staff_inquiries')
@@ -36,6 +45,12 @@ export default function AdminInquiriesPage() {
   const setStatus = async (id: string, status: string) => {
     await sb.from('staff_inquiries').update({ status }).eq('id', id)
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, status } : r)))
+  }
+
+  const openMessage = (row: Row) => {
+    setViewTarget(row)
+    // Mark a brand-new inquiry as read once it's opened.
+    if (row.status === 'new') void setStatus(row.id, 'read')
   }
 
   return (
@@ -76,6 +91,9 @@ export default function AdminInquiriesPage() {
                     <Badge>{r.status}</Badge>
                   </TableCell>
                   <TableCell className="space-x-1 text-right">
+                    <Button variant="secondary" size="sm" type="button" onClick={() => openMessage(r)}>
+                      View
+                    </Button>
                     <Button variant="outline" size="sm" type="button" onClick={() => void setStatus(r.id, 'read')}>
                       Read
                     </Button>
@@ -90,6 +108,53 @@ export default function AdminInquiriesPage() {
           {visible.length === 0 && <p className="text-sm text-muted-foreground py-8 text-center">No inquiries yet.</p>}
         </CardContent>
       </Card>
+
+      <Dialog open={!!viewTarget} onOpenChange={(open) => { if (!open) setViewTarget(null) }}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="font-display text-xl font-black tracking-tight">
+              {viewTarget?.operator_name}
+            </DialogTitle>
+            <DialogDescription>
+              {viewTarget?.email}
+              {viewTarget?.created_at
+                ? ` · ${new Date(viewTarget.created_at).toLocaleString()}`
+                : ''}
+            </DialogDescription>
+          </DialogHeader>
+          {viewTarget && (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                {viewTarget.mission_type && (
+                  <Badge variant="outline">{viewTarget.mission_type}</Badge>
+                )}
+                <Badge>{viewTarget.status}</Badge>
+              </div>
+              <div className="max-h-[50vh] overflow-y-auto whitespace-pre-wrap rounded-xl border border-gray-100 bg-gray-50/80 p-4 text-sm leading-relaxed text-foreground">
+                {viewTarget.message}
+              </div>
+            </div>
+          )}
+          <DialogFooter className="gap-2 sm:gap-0">
+            {viewTarget?.email && (
+              <Button asChild variant="outline">
+                <a href={`mailto:${viewTarget.email}`}>Reply by email</a>
+              </Button>
+            )}
+            {viewTarget && (
+              <Button
+                type="button"
+                onClick={() => {
+                  void setStatus(viewTarget.id, 'resolved')
+                  setViewTarget(null)
+                }}
+              >
+                Mark resolved
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src/app/admin/inventory/page.tsx
+++ b/src/app/admin/inventory/page.tsx
@@ -21,10 +21,33 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Switch } from '@/components/ui/switch'
+import { ImageUploadField } from '@/components/admin/image-upload-field'
 import { cn } from '@/lib/utils'
 
 function isLowStock(prize: Prize) {
   return prize.stock_quantity <= prize.reorder_threshold
+}
+
+type PrizeForm = {
+  name: string
+  description: string
+  ticket_cost: string
+  stock_quantity: string
+  reorder_threshold: string
+  category: string
+  is_active: boolean
+  image_url: string | null
+}
+
+const EMPTY_PRIZE_FORM: PrizeForm = {
+  name: '',
+  description: '',
+  ticket_cost: '',
+  stock_quantity: '0',
+  reorder_threshold: '5',
+  category: 'general',
+  is_active: true,
+  image_url: null,
 }
 
 export default function InventoryPage() {
@@ -34,15 +57,11 @@ export default function InventoryPage() {
   const [loading, setLoading] = useState(true)
   const [addOpen, setAddOpen] = useState(false)
   const [saving, setSaving] = useState(false)
-  const [form, setForm] = useState({
-    name: '',
-    description: '',
-    ticket_cost: '',
-    stock_quantity: '0',
-    reorder_threshold: '5',
-    category: 'general',
-    is_active: true,
-  })
+  const [form, setForm] = useState<PrizeForm>(EMPTY_PRIZE_FORM)
+
+  const [editTarget, setEditTarget] = useState<Prize | null>(null)
+  const [editForm, setEditForm] = useState<PrizeForm>(EMPTY_PRIZE_FORM)
+  const [editSaving, setEditSaving] = useState(false)
 
   const [stockTarget, setStockTarget] = useState<Prize | null>(null)
   const [stockInput, setStockInput] = useState('')
@@ -80,15 +99,7 @@ export default function InventoryPage() {
   }, [authLoading, loadPrizes])
 
   const resetAddForm = () => {
-    setForm({
-      name: '',
-      description: '',
-      ticket_cost: '',
-      stock_quantity: '0',
-      reorder_threshold: '5',
-      category: 'general',
-      is_active: true,
-    })
+    setForm(EMPTY_PRIZE_FORM)
   }
 
   const handleAddPrize = async (e: React.FormEvent) => {
@@ -124,7 +135,7 @@ export default function InventoryPage() {
         reorder_threshold: Math.round(reorder),
         category: form.category.trim() || 'general',
         is_active: form.is_active,
-        image_url: null,
+        image_url: form.image_url,
       })
 
       if (error) {
@@ -140,6 +151,69 @@ export default function InventoryPage() {
       toast.error('Could not add prize')
     } finally {
       setSaving(false)
+    }
+  }
+
+  const openEditDialog = (prize: Prize) => {
+    setEditTarget(prize)
+    setEditForm({
+      name: prize.name,
+      description: prize.description ?? '',
+      ticket_cost: String(prize.ticket_cost),
+      stock_quantity: String(prize.stock_quantity),
+      reorder_threshold: String(prize.reorder_threshold),
+      category: prize.category,
+      is_active: prize.is_active,
+      image_url: prize.image_url,
+    })
+  }
+
+  const handleEditPrize = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!editTarget) return
+    const name = editForm.name.trim()
+    if (!name) {
+      toast.error('Name is required')
+      return
+    }
+    const ticketCost = Number(editForm.ticket_cost)
+    const reorder = Number(editForm.reorder_threshold)
+    if (!Number.isFinite(ticketCost) || ticketCost < 0) {
+      toast.error('Enter a valid ticket cost')
+      return
+    }
+    if (!Number.isFinite(reorder) || reorder < 0) {
+      toast.error('Enter a valid reorder threshold')
+      return
+    }
+
+    setEditSaving(true)
+    try {
+      const { error } = await supabase
+        .from('prizes')
+        .update({
+          name,
+          description: editForm.description.trim() || null,
+          ticket_cost: Math.round(ticketCost),
+          reorder_threshold: Math.round(reorder),
+          category: editForm.category.trim() || 'general',
+          is_active: editForm.is_active,
+          image_url: editForm.image_url,
+        })
+        .eq('id', editTarget.id)
+
+      if (error) {
+        toast.error(error.message || 'Could not update prize')
+        return
+      }
+      toast.success('Prize updated')
+      setEditTarget(null)
+      await loadPrizes()
+    } catch (err) {
+      console.error(err)
+      toast.error('Could not update prize')
+    } finally {
+      setEditSaving(false)
     }
   }
 
@@ -280,6 +354,16 @@ export default function InventoryPage() {
                 )}
               >
                 <CardHeader className="gap-3">
+                  {prize.image_url && (
+                    <div className="overflow-hidden rounded-xl border border-gray-100 bg-gray-50">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={prize.image_url}
+                        alt={prize.name}
+                        className="h-36 w-full object-cover"
+                      />
+                    </div>
+                  )}
                   <div className="flex items-start justify-between gap-2">
                     <CardTitle className="font-display text-lg font-black tracking-tight">
                       {prize.name}
@@ -363,6 +447,15 @@ export default function InventoryPage() {
                       <PencilLine className="size-4" />
                       Stock
                     </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="rounded-xl font-black uppercase tracking-widest"
+                      onClick={() => openEditDialog(prize)}
+                    >
+                      <PencilLine className="size-4" />
+                      Edit
+                    </Button>
                   </div>
                 </CardContent>
               </Card>
@@ -404,6 +497,13 @@ export default function InventoryPage() {
                   className="rounded-xl"
                 />
               </div>
+              <ImageUploadField
+                folder="prizes"
+                entityId="new"
+                value={form.image_url}
+                onChange={(url) => setForm((f) => ({ ...f, image_url: url }))}
+                disabled={saving}
+              />
               <div className="grid grid-cols-2 gap-3">
                 <div className="grid gap-2">
                   <Label htmlFor="ticket-cost">Ticket cost</Label>
@@ -478,6 +578,118 @@ export default function InventoryPage() {
                 className="rounded-xl font-black uppercase tracking-widest"
               >
                 {saving ? 'Saving…' : 'Save prize'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!editTarget}
+        onOpenChange={(open) => {
+          if (!open) setEditTarget(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <form onSubmit={handleEditPrize}>
+            <DialogHeader>
+              <DialogTitle className="font-display text-xl font-black tracking-tight">
+                Edit prize
+              </DialogTitle>
+              <DialogDescription>
+                Update pricing, details, and the product picture.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-2">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-prize-name">Name</Label>
+                <Input
+                  id="edit-prize-name"
+                  value={editForm.name}
+                  onChange={(e) => setEditForm((f) => ({ ...f, name: e.target.value }))}
+                  required
+                  className="rounded-xl"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-prize-desc">Description</Label>
+                <Input
+                  id="edit-prize-desc"
+                  value={editForm.description}
+                  onChange={(e) => setEditForm((f) => ({ ...f, description: e.target.value }))}
+                  placeholder="Short description"
+                  className="rounded-xl"
+                />
+              </div>
+              <ImageUploadField
+                folder="prizes"
+                entityId={editTarget?.id ?? 'prize'}
+                value={editForm.image_url}
+                onChange={(url) => setEditForm((f) => ({ ...f, image_url: url }))}
+                disabled={editSaving}
+              />
+              <div className="grid grid-cols-2 gap-3">
+                <div className="grid gap-2">
+                  <Label htmlFor="edit-ticket-cost">Ticket cost</Label>
+                  <Input
+                    id="edit-ticket-cost"
+                    type="number"
+                    min={0}
+                    value={editForm.ticket_cost}
+                    onChange={(e) => setEditForm((f) => ({ ...f, ticket_cost: e.target.value }))}
+                    className="rounded-xl"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="edit-reorder">Reorder threshold</Label>
+                  <Input
+                    id="edit-reorder"
+                    type="number"
+                    min={0}
+                    value={editForm.reorder_threshold}
+                    onChange={(e) =>
+                      setEditForm((f) => ({ ...f, reorder_threshold: e.target.value }))
+                    }
+                    className="rounded-xl"
+                  />
+                </div>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-category">Category</Label>
+                <Input
+                  id="edit-category"
+                  value={editForm.category}
+                  onChange={(e) => setEditForm((f) => ({ ...f, category: e.target.value }))}
+                  placeholder="general"
+                  className="rounded-xl"
+                />
+              </div>
+              <div className="flex items-center justify-between rounded-xl border border-gray-100 bg-gray-50/80 px-4 py-3">
+                <Label htmlFor="edit-prize-active" className="cursor-pointer font-medium">
+                  Listed as active
+                </Label>
+                <Switch
+                  id="edit-prize-active"
+                  checked={editForm.is_active}
+                  onCheckedChange={(v) => setEditForm((f) => ({ ...f, is_active: v }))}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-xl font-black uppercase tracking-widest"
+                onClick={() => setEditTarget(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={editSaving}
+                className="rounded-xl font-black uppercase tracking-widest"
+              >
+                {editSaving ? 'Saving…' : 'Save changes'}
               </Button>
             </DialogFooter>
           </form>

--- a/src/app/admin/machines/page.tsx
+++ b/src/app/admin/machines/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/hooks/use-auth'
 import { safeFormatDate, cn } from '@/lib/utils'
 import type { Machine, MachineStatus } from '@/types/database'
 import { toast } from 'sonner'
-import { Cpu } from 'lucide-react'
+import { Cpu, Pencil, Trash2 } from 'lucide-react'
 import {
   Card,
   CardContent,
@@ -22,7 +22,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -32,6 +43,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
+import { ImageUploadField } from '@/components/admin/image-upload-field'
 
 const STATUS_BADGE: Record<MachineStatus, string> = {
   active: 'border border-emerald-200/80 bg-emerald-50 text-emerald-800',
@@ -61,6 +73,26 @@ function MachineCardSkeleton() {
   )
 }
 
+type MachineForm = {
+  name: string
+  machine_type: string
+  tokens_per_play: string
+  location_note: string
+  serial_number: string
+  description: string
+  image_url: string | null
+}
+
+const EMPTY_MACHINE_FORM: MachineForm = {
+  name: '',
+  machine_type: '',
+  tokens_per_play: '1',
+  location_note: '',
+  serial_number: '',
+  description: '',
+  image_url: null,
+}
+
 export default function MachinesPage() {
   const { isManager } = useAuth()
   const supabase = useMemo(() => createClient(), [])
@@ -69,13 +101,14 @@ export default function MachinesPage() {
   const [addOpen, setAddOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [statusSavingId, setStatusSavingId] = useState<string | null>(null)
-  const [form, setForm] = useState({
-    name: '',
-    machine_type: '',
-    tokens_per_play: '1',
-    location_note: '',
-    serial_number: '',
-  })
+  const [form, setForm] = useState<MachineForm>(EMPTY_MACHINE_FORM)
+
+  const [editTarget, setEditTarget] = useState<Machine | null>(null)
+  const [editForm, setEditForm] = useState<MachineForm>(EMPTY_MACHINE_FORM)
+  const [editSaving, setEditSaving] = useState(false)
+
+  const [deleteTarget, setDeleteTarget] = useState<Machine | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   const canManage = isManager()
 
@@ -145,13 +178,7 @@ export default function MachinesPage() {
   }
 
   const resetForm = () => {
-    setForm({
-      name: '',
-      machine_type: '',
-      tokens_per_play: '1',
-      location_note: '',
-      serial_number: '',
-    })
+    setForm(EMPTY_MACHINE_FORM)
   }
 
   const addMachine = async () => {
@@ -184,6 +211,8 @@ export default function MachinesPage() {
           tokens_per_play: tokens,
           location_note,
           serial_number,
+          description: form.description.trim() || null,
+          image_url: form.image_url,
           status: 'active',
         })
         .select('*')
@@ -205,6 +234,93 @@ export default function MachinesPage() {
       toast.error(message)
     } finally {
       setSaving(false)
+    }
+  }
+
+  const openEditDialog = (machine: Machine) => {
+    if (!canManage) {
+      toast.error('Only managers and owners can edit machines')
+      return
+    }
+    setEditTarget(machine)
+    setEditForm({
+      name: machine.name,
+      machine_type: machine.machine_type,
+      tokens_per_play: String(machine.tokens_per_play),
+      location_note: machine.location_note ?? '',
+      serial_number: machine.serial_number ?? '',
+      description: machine.description ?? '',
+      image_url: machine.image_url ?? null,
+    })
+  }
+
+  const saveEdit = async () => {
+    if (!editTarget) return
+    const name = editForm.name.trim()
+    const machineType = editForm.machine_type.trim()
+    const tokens = Number.parseInt(editForm.tokens_per_play, 10)
+    if (!name || !machineType) {
+      toast.error('Name and machine type are required')
+      return
+    }
+    if (!Number.isFinite(tokens) || tokens < 1) {
+      toast.error('Tokens per play must be at least 1')
+      return
+    }
+
+    setEditSaving(true)
+    try {
+      const { data, error } = await supabase
+        .from('machines')
+        .update({
+          name,
+          machine_type: machineType,
+          tokens_per_play: tokens,
+          location_note: editForm.location_note.trim() || null,
+          serial_number: editForm.serial_number.trim() || null,
+          description: editForm.description.trim() || null,
+          image_url: editForm.image_url,
+        })
+        .eq('id', editTarget.id)
+        .select('*')
+        .single()
+
+      if (error) throw error
+      if (data) {
+        setMachines((prev) =>
+          prev
+            .map((m) => (m.id === editTarget.id ? (data as Machine) : m))
+            .sort((a, b) => a.name.localeCompare(b.name))
+        )
+      }
+      toast.success('Machine updated')
+      setEditTarget(null)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Could not update machine'
+      toast.error(message)
+    } finally {
+      setEditSaving(false)
+    }
+  }
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    try {
+      const { error } = await supabase
+        .from('machines')
+        .delete()
+        .eq('id', deleteTarget.id)
+
+      if (error) throw error
+      setMachines((prev) => prev.filter((m) => m.id !== deleteTarget.id))
+      toast.success('Machine deleted')
+      setDeleteTarget(null)
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Could not delete machine'
+      toast.error(message)
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -295,6 +411,16 @@ export default function MachinesPage() {
               className="rounded-2xl border border-gray-100 bg-white shadow-sm"
             >
               <CardHeader className="space-y-3">
+                {m.image_url && (
+                  <div className="overflow-hidden rounded-xl border border-gray-100 bg-gray-50">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={m.image_url}
+                      alt={m.name}
+                      className="h-36 w-full object-cover"
+                    />
+                  </div>
+                )}
                 <div className="flex items-start justify-between gap-2">
                   <CardTitle className="font-display text-lg font-black leading-tight tracking-tight">
                     {m.name}
@@ -310,6 +436,11 @@ export default function MachinesPage() {
                   </Badge>
                 </div>
                 <p className="text-sm text-muted-foreground">{m.machine_type}</p>
+                {m.description && (
+                  <p className="text-sm leading-relaxed text-foreground/80">
+                    {m.description}
+                  </p>
+                )}
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="flex flex-wrap items-center gap-2 text-sm">
@@ -367,6 +498,31 @@ export default function MachinesPage() {
                     {safeFormatDate(m.updated_at, 'MMM d, yyyy h:mm a')}
                   </p>
                 </div>
+
+                {canManage && (
+                  <div className="flex gap-2 border-t border-gray-100 pt-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="flex-1 rounded-xl"
+                      onClick={() => openEditDialog(m)}
+                    >
+                      <Pencil className="size-4" />
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="rounded-xl text-red-600 hover:bg-red-50 hover:text-red-700"
+                      onClick={() => setDeleteTarget(m)}
+                    >
+                      <Trash2 className="size-4" />
+                      Delete
+                    </Button>
+                  </div>
+                )}
               </CardContent>
             </Card>
           ))}
@@ -448,6 +604,26 @@ export default function MachinesPage() {
                 placeholder="Optional"
               />
             </div>
+            <div className="grid gap-2">
+              <Label htmlFor="machine-description">Description</Label>
+              <Textarea
+                id="machine-description"
+                className="rounded-xl"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+                placeholder="Notes about this machine (game details, condition, etc.)"
+                rows={3}
+              />
+            </div>
+            <ImageUploadField
+              folder="machines"
+              entityId="new"
+              value={form.image_url}
+              onChange={(url) => setForm((f) => ({ ...f, image_url: url }))}
+              disabled={saving}
+            />
           </div>
           <DialogFooter className="gap-2 sm:gap-0">
             <Button
@@ -472,6 +648,151 @@ export default function MachinesPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <Dialog
+        open={!!editTarget}
+        onOpenChange={(open) => {
+          if (!open) setEditTarget(null)
+        }}
+      >
+        <DialogContent className="max-w-lg rounded-2xl border border-gray-100 bg-white shadow-lg sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="font-display text-xl font-black tracking-tight">
+              Edit machine
+            </DialogTitle>
+          </DialogHeader>
+          <div className="grid max-h-[70vh] gap-4 overflow-y-auto py-2 pr-1">
+            <div className="grid gap-2">
+              <Label htmlFor="edit-machine-name">Name</Label>
+              <Input
+                id="edit-machine-name"
+                className="rounded-xl"
+                value={editForm.name}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, name: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-machine-type">Machine type</Label>
+              <Input
+                id="edit-machine-type"
+                className="rounded-xl"
+                value={editForm.machine_type}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, machine_type: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-tokens-per-play">Tokens per play</Label>
+              <Input
+                id="edit-tokens-per-play"
+                type="number"
+                min={1}
+                className="rounded-xl"
+                value={editForm.tokens_per_play}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, tokens_per_play: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-location-note">Location note</Label>
+              <Input
+                id="edit-location-note"
+                className="rounded-xl"
+                value={editForm.location_note}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, location_note: e.target.value }))
+                }
+                placeholder="Floor area, row, or landmark"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-serial-number">Serial number</Label>
+              <Input
+                id="edit-serial-number"
+                className="rounded-xl"
+                value={editForm.serial_number}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, serial_number: e.target.value }))
+                }
+                placeholder="Optional"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="edit-machine-description">Description</Label>
+              <Textarea
+                id="edit-machine-description"
+                className="rounded-xl"
+                value={editForm.description}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, description: e.target.value }))
+                }
+                placeholder="Notes about this machine (game details, condition, etc.)"
+                rows={3}
+              />
+            </div>
+            <ImageUploadField
+              folder="machines"
+              entityId={editTarget?.id ?? 'machine'}
+              value={editForm.image_url}
+              onChange={(url) => setEditForm((f) => ({ ...f, image_url: url }))}
+              disabled={editSaving}
+            />
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-xl"
+              onClick={() => setEditTarget(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="rounded-xl"
+              disabled={editSaving}
+              onClick={saveEdit}
+            >
+              {editSaving ? 'Saving…' : 'Save changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this machine?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteTarget
+                ? `"${deleteTarget.name}" will be permanently removed from the directory. This can't be undone.`
+                : ''}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void confirmDelete()
+              }}
+              disabled={deleting}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              {deleting ? 'Deleting…' : 'Delete machine'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/app/admin/tokens/page.tsx
+++ b/src/app/admin/tokens/page.tsx
@@ -19,13 +19,42 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { Calendar, Coins, DollarSign, Loader2, Receipt } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { PaymentType } from '@/types/database'
+import { Calendar, Coins, DollarSign, Loader2, Pencil, Receipt, Trash2 } from 'lucide-react'
 
 const PAGE_SIZE = 25
 
 export default function AdminTokensPage() {
-  const { loading: authLoading } = useAuth()
+  const { loading: authLoading, isManager } = useAuth()
   const supabase = useMemo(() => createClient(), [])
+  const canManage = isManager()
 
   const [transactions, setTransactions] = useState<TokenTransaction[]>([])
   const [stats, setStats] = useState({
@@ -36,6 +65,17 @@ export default function AdminTokensPage() {
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [hasMore, setHasMore] = useState(true)
+
+  const [editTarget, setEditTarget] = useState<TokenTransaction | null>(null)
+  const [editForm, setEditForm] = useState({
+    amount_paid: '',
+    tokens_given: '',
+    payment_type: 'cash' as PaymentType,
+  })
+  const [editSaving, setEditSaving] = useState(false)
+
+  const [deleteTarget, setDeleteTarget] = useState<TokenTransaction | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   const sumAmountPaid = (rows: { amount_paid: number | string }[] | null) =>
     (rows ?? []).reduce((s, r) => s + Number(r.amount_paid ?? 0), 0)
@@ -116,6 +156,79 @@ export default function AdminTokensPage() {
       toast.error('Failed to load more transactions')
     } finally {
       setLoadingMore(false)
+    }
+  }
+
+  const openEdit = (tx: TokenTransaction) => {
+    setEditTarget(tx)
+    setEditForm({
+      amount_paid: String(tx.amount_paid),
+      tokens_given: String(tx.tokens_given),
+      payment_type: tx.payment_type,
+    })
+  }
+
+  const saveEdit = async () => {
+    if (!editTarget) return
+    const amount = Number(editForm.amount_paid)
+    const tokens = Number(editForm.tokens_given)
+    if (!Number.isFinite(amount) || amount < 0) {
+      toast.error('Enter a valid amount paid')
+      return
+    }
+    if (!Number.isInteger(tokens) || tokens < 0) {
+      toast.error('Enter a valid token count')
+      return
+    }
+    setEditSaving(true)
+    try {
+      const { data, error } = await supabase
+        .from('token_transactions')
+        .update({
+          amount_paid: amount,
+          tokens_given: tokens,
+          payment_type: editForm.payment_type,
+        })
+        .eq('id', editTarget.id)
+        .select('*')
+        .single()
+
+      if (error) throw error
+      if (data) {
+        setTransactions((prev) =>
+          prev.map((t) => (t.id === editTarget.id ? (data as TokenTransaction) : t))
+        )
+      }
+      await fetchStats()
+      toast.success('Transaction updated')
+      setEditTarget(null)
+    } catch (err) {
+      console.error('Token transaction update error:', err)
+      toast.error(err instanceof Error ? err.message : 'Could not update transaction')
+    } finally {
+      setEditSaving(false)
+    }
+  }
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    try {
+      const { error } = await supabase
+        .from('token_transactions')
+        .delete()
+        .eq('id', deleteTarget.id)
+
+      if (error) throw error
+      setTransactions((prev) => prev.filter((t) => t.id !== deleteTarget.id))
+      await fetchStats()
+      toast.success('Transaction deleted')
+      setDeleteTarget(null)
+    } catch (err) {
+      console.error('Token transaction delete error:', err)
+      toast.error(err instanceof Error ? err.message : 'Could not delete transaction')
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -233,6 +346,7 @@ export default function AdminTokensPage() {
                     <TableHead className="text-right">Tokens given</TableHead>
                     <TableHead>Payment type</TableHead>
                     <TableHead>Bonus</TableHead>
+                    {canManage && <TableHead className="text-right">Actions</TableHead>}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -272,6 +386,32 @@ export default function AdminTokensPage() {
                           <span className="text-sm text-muted-foreground">—</span>
                         )}
                       </TableCell>
+                      {canManage && (
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-1">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="rounded-xl"
+                              onClick={() => openEdit(tx)}
+                            >
+                              <Pencil className="size-4" />
+                              <span className="sr-only">Edit</span>
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="rounded-xl text-red-600 hover:bg-red-50 hover:text-red-700"
+                              onClick={() => setDeleteTarget(tx)}
+                            >
+                              <Trash2 className="size-4" />
+                              <span className="sr-only">Delete</span>
+                            </Button>
+                          </div>
+                        </TableCell>
+                      )}
                     </TableRow>
                   ))}
                 </TableBody>
@@ -301,6 +441,121 @@ export default function AdminTokensPage() {
           )}
         </CardContent>
       </Card>
+
+      <Dialog
+        open={!!editTarget}
+        onOpenChange={(open) => {
+          if (!open) setEditTarget(null)
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="font-display text-xl font-black tracking-tight">
+              Edit transaction
+            </DialogTitle>
+            <DialogDescription>
+              Correct a processed token sale. Totals update automatically.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-2">
+            <div className="grid gap-2">
+              <Label htmlFor="tx-amount">Amount paid ($)</Label>
+              <Input
+                id="tx-amount"
+                type="number"
+                min={0}
+                step="0.01"
+                className="rounded-xl"
+                value={editForm.amount_paid}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, amount_paid: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="tx-tokens">Tokens given</Label>
+              <Input
+                id="tx-tokens"
+                type="number"
+                min={0}
+                className="rounded-xl"
+                value={editForm.tokens_given}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, tokens_given: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="tx-payment">Payment type</Label>
+              <Select
+                value={editForm.payment_type}
+                onValueChange={(v) =>
+                  setEditForm((f) => ({ ...f, payment_type: v as PaymentType }))
+                }
+              >
+                <SelectTrigger id="tx-payment" className="w-full rounded-xl">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="cash">Cash</SelectItem>
+                  <SelectItem value="card">Card</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-xl"
+              onClick={() => setEditTarget(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="rounded-xl"
+              disabled={editSaving}
+              onClick={() => void saveEdit()}
+            >
+              {editSaving ? 'Saving…' : 'Save changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this transaction?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteTarget
+                ? `This will permanently remove the ${currency(
+                    Number(deleteTarget.amount_paid)
+                  )} sale (${deleteTarget.tokens_given} tokens). Revenue totals will adjust. This can't be undone.`
+                : ''}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault()
+                void confirmDelete()
+              }}
+              disabled={deleting}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              {deleting ? 'Deleting…' : 'Delete transaction'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/components/admin/image-upload-field.tsx
+++ b/src/components/admin/image-upload-field.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import { uploadMediaImage } from '@/lib/storage'
+import { Button } from '@/components/ui/button'
+import { ImagePlus, Loader2, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+
+type ImageUploadFieldProps = {
+  /** Storage subfolder, e.g. 'prizes' or 'machines'. */
+  folder: string
+  /** Stable id for the entity (used in the filename). */
+  entityId: string
+  /** Current image URL (controlled). */
+  value: string | null
+  /** Called with the new public URL, or null when removed. */
+  onChange: (url: string | null) => void
+  disabled?: boolean
+  label?: string
+}
+
+export function ImageUploadField({
+  folder,
+  entityId,
+  value,
+  onChange,
+  disabled,
+  label = 'Picture',
+}: ImageUploadFieldProps) {
+  const supabase = useMemo(() => createClient(), [])
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file) return
+    setUploading(true)
+    try {
+      const result = await uploadMediaImage(supabase, folder, entityId, file)
+      if ('error' in result) {
+        toast.error(result.error)
+        return
+      }
+      onChange(result.url)
+      toast.success('Image uploaded')
+    } catch (err) {
+      console.error('Image upload error:', err)
+      toast.error('Could not upload image')
+    } finally {
+      setUploading(false)
+      if (inputRef.current) inputRef.current.value = ''
+    }
+  }
+
+  return (
+    <div className="grid gap-2">
+      <span className="text-sm font-medium">{label}</span>
+      <div className="flex items-center gap-3">
+        <div
+          className={cn(
+            'relative flex size-20 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-dashed border-gray-200 bg-gray-50 text-gray-400',
+            value && 'border-solid'
+          )}
+        >
+          {value ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={value} alt="" className="size-full object-cover" />
+          ) : (
+            <ImagePlus className="size-6" aria-hidden />
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="rounded-xl"
+            disabled={disabled || uploading}
+            onClick={() => inputRef.current?.click()}
+          >
+            {uploading ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Uploading…
+              </>
+            ) : value ? (
+              'Replace'
+            ) : (
+              'Upload image'
+            )}
+          </Button>
+          {value && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="rounded-xl text-red-600 hover:bg-red-50 hover:text-red-700"
+              disabled={disabled || uploading}
+              onClick={() => onChange(null)}
+            >
+              <Trash2 className="size-4" />
+              Remove
+            </Button>
+          )}
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/gif"
+          className="hidden"
+          onChange={(e) => void handleFile(e.target.files?.[0])}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,11 +16,14 @@ export const BUSINESS_INFO = {
   brandColor: '#DC2626',
 }
 
+// Flat rate: $1 = 3 tokens at every amount. The old 10% bulk bonus was removed
+// per the client (Jun 2026) — seasonal deals (e.g. "$100 gets $10 free") are now
+// run through staff-issued coupons instead, so they can be toggled on/off.
 export const TOKEN_PRICING = [
   { price: 1, tokens: 3, label: '$1 = 3 Tokens' },
   { price: 5, tokens: 15, label: '$5 = 15 Tokens' },
   { price: 10, tokens: 30, label: '$10 = 30 Tokens' },
-  { price: 20, tokens: 66, label: '$20 = 66 Tokens (10% savings!)' },
+  { price: 20, tokens: 60, label: '$20 = 60 Tokens' },
 ] as const
 
 export const CARD_MINIMUM = 10

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/** Public Supabase Storage bucket created in migration 00021. */
+export const MEDIA_BUCKET = 'media'
+
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5 MB
+export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+
+function fileExtension(file: File): string {
+  const fromName = file.name.includes('.') ? file.name.split('.').pop() : ''
+  const ext = (fromName || file.type.split('/')[1] || 'jpg').toLowerCase()
+  // keep it filesystem/url-safe
+  return ext.replace(/[^a-z0-9]/g, '') || 'jpg'
+}
+
+export type UploadResult = { url: string } | { error: string }
+
+/**
+ * Upload an image to the public `media` bucket under `${folder}/...` and return
+ * its public URL. Validates type and size before uploading.
+ *
+ * @param folder e.g. 'prizes' or 'machines'
+ * @param entityId stable id used in the filename (falls back to a random id)
+ */
+export async function uploadMediaImage(
+  supabase: SupabaseClient,
+  folder: string,
+  entityId: string,
+  file: File
+): Promise<UploadResult> {
+  if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+    return { error: 'Please choose a JPG, PNG, WEBP, or GIF image.' }
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return { error: 'Image must be 5 MB or smaller.' }
+  }
+
+  const id = entityId || Math.random().toString(36).slice(2)
+  const path = `${folder}/${id}-${Date.now()}.${fileExtension(file)}`
+
+  const { error } = await supabase.storage.from(MEDIA_BUCKET).upload(path, file, {
+    cacheControl: '3600',
+    upsert: true,
+    contentType: file.type,
+  })
+
+  if (error) {
+    return { error: error.message || 'Upload failed' }
+  }
+
+  const { data } = supabase.storage.from(MEDIA_BUCKET).getPublicUrl(path)
+  return { url: data.publicUrl }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -51,6 +51,8 @@ export interface Machine {
   tokens_per_play: number
   status: MachineStatus
   location_note: string | null
+  description: string | null
+  image_url: string | null
   purchase_date: string | null
   serial_number: string | null
   created_at: string

--- a/supabase/migrations/00019_machines_description_image_delete.sql
+++ b/supabase/migrations/00019_machines_description_image_delete.sql
@@ -1,0 +1,19 @@
+-- 00019: Machines — editable description, picture, and delete capability
+--
+-- Customer request (Jun 2026):
+--   • "Machines - Ability to edit within the description for each one /
+--      delete ones no longer inventoried"
+--   • "Machines - Picture section slotted"
+--
+-- Adds two optional columns and a DELETE RLS policy for staff managers/owners.
+-- Safe to run multiple times (idempotent).
+
+ALTER TABLE public.machines ADD COLUMN IF NOT EXISTS description text;
+ALTER TABLE public.machines ADD COLUMN IF NOT EXISTS image_url   text;
+
+-- The initial schema gave machines INSERT/UPDATE/SELECT policies but no DELETE.
+-- Allow managers and owners to remove machines that are no longer inventoried.
+DROP POLICY IF EXISTS "Managers+ can delete machines" ON public.machines;
+CREATE POLICY "Managers+ can delete machines"
+  ON public.machines FOR DELETE
+  USING (public.is_manager_or_owner());

--- a/supabase/migrations/00020_token_transactions_edit_delete.sql
+++ b/supabase/migrations/00020_token_transactions_edit_delete.sql
@@ -1,0 +1,20 @@
+-- 00020: Token transactions — allow correcting / removing processed sales
+--
+-- Customer request (Jun 2026):
+--   • "Ability to delete out token purchases (or edit them after processed)"
+--
+-- The initial schema only allowed INSERT (employees+) and SELECT on
+-- token_transactions. This adds UPDATE and DELETE for managers/owners so a
+-- mistaken or duplicate sale can be corrected or removed after the fact.
+-- Safe to run multiple times (idempotent).
+
+DROP POLICY IF EXISTS "Managers+ can update token transactions" ON public.token_transactions;
+CREATE POLICY "Managers+ can update token transactions"
+  ON public.token_transactions FOR UPDATE
+  USING (public.is_manager_or_owner())
+  WITH CHECK (public.is_manager_or_owner());
+
+DROP POLICY IF EXISTS "Managers+ can delete token transactions" ON public.token_transactions;
+CREATE POLICY "Managers+ can delete token transactions"
+  ON public.token_transactions FOR DELETE
+  USING (public.is_manager_or_owner());

--- a/supabase/migrations/00021_storage_media_bucket.sql
+++ b/supabase/migrations/00021_storage_media_bucket.sql
@@ -1,0 +1,47 @@
+-- 00021: Public "media" storage bucket for prize & machine pictures
+--
+-- Customer request (Jun 2026):
+--   • "Prize Inventory - Picture section associated with each product"
+--   • "Machines - Picture section slotted"
+--
+-- Creates a single PUBLIC bucket named `media` (images are non-sensitive product
+-- photos, so public read keeps display simple — no signed URLs needed).
+-- Uploads/edits/deletes are restricted to authenticated staff via is_staff().
+--
+-- Folder convention used by the app:
+--   media/prizes/<id>-<timestamp>.<ext>
+--   media/machines/<id>-<timestamp>.<ext>
+--
+-- Safe to run multiple times (idempotent).
+
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('media', 'media', true)
+ON CONFLICT (id) DO UPDATE SET public = true;
+
+-- Anyone can READ objects in the media bucket (bucket is public).
+DROP POLICY IF EXISTS "Public read media" ON storage.objects;
+CREATE POLICY "Public read media"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'media');
+
+-- Only staff (owner/manager/employee) may upload.
+DROP POLICY IF EXISTS "Staff upload media" ON storage.objects;
+CREATE POLICY "Staff upload media"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (bucket_id = 'media' AND public.is_staff());
+
+-- Only staff may replace existing objects.
+DROP POLICY IF EXISTS "Staff update media" ON storage.objects;
+CREATE POLICY "Staff update media"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (bucket_id = 'media' AND public.is_staff())
+  WITH CHECK (bucket_id = 'media' AND public.is_staff());
+
+-- Only staff may delete objects.
+DROP POLICY IF EXISTS "Staff delete media" ON storage.objects;
+CREATE POLICY "Staff delete media"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (bucket_id = 'media' AND public.is_staff());


### PR DESCRIPTION
# PR: Customer corrections — June 2026 (Madison Condurso email)

Implements the "Corrections to Mainstream Back End" list from the client.
Branch: `feat/customer-corrections-jun2026` → base `feat/sfms-implementation-plan-v3`.

## ⚠️ Run these migrations before/at deploy (in order)

These features need DB changes. Run in the Supabase SQL editor in numeric order:

- `supabase/migrations/00019_machines_description_image_delete.sql`
  — adds `machines.description`, `machines.image_url`, and a DELETE policy for managers/owners.
- `supabase/migrations/00020_token_transactions_edit_delete.sql`
  — adds UPDATE + DELETE policies on `token_transactions` for managers/owners.
- `supabase/migrations/00021_storage_media_bucket.sql`
  — creates the public `media` storage bucket + policies for prize/machine images.

All three are idempotent (safe to re-run). The frontend compiles without them,
but the new buttons will error at runtime until they're applied.

## Fixed

- **Prize Inventory — edit price.** New **Edit** dialog on each prize: name,
  description, **ticket cost (price)**, category, reorder threshold, active, and
  picture. (Stock keeps its existing quick-edit button.)
- **Remove the token percentage add.** Token pricing is now flat **3 tokens per
  $1** (`$20 = 60`, was 66 "10% savings"). Removed the "+6 Bonus Tokens" /
  "savings" labels from the live home and pricing pages. Seasonal deals (e.g.
  "$100 gets $10 free") are meant to run through **coupons** so they can be
  toggled on/off — no code change needed to switch a deal on/off.
- **Machines — edit description + delete.** New **Edit** dialog (incl. a
  description field) and a **Delete** action (with confirm) for machines no
  longer inventoried.
- **Email requests — view full message.** The inquiries inbox previously never
  showed the message body. Added a **View** dialog with the full message,
  sender, topic, timestamp, a "Reply by email" link, and auto-marks new
  inquiries as read.
- **Party Bookings — view full message.** Added a **View** dialog showing the
  full `special requests` message plus contact email, guest counts, deposit, and
  totals.

## Added

- **Prize Inventory — picture per product.** Upload/replace/remove an image;
  shown on the prize card (and already surfaced on the customer prizes page).
- **Machines — picture slotted.** Same upload control; shown on the machine card.
- **Delete / edit token purchases after processing.** Token transaction log now
  has per-row **Edit** (amount, tokens, payment type) and **Delete** (with
  confirm); revenue stats refresh automatically. Owner/manager only.

## Implementation notes

- Images upload to a single public Supabase Storage bucket `media`
  (`media/prizes/…`, `media/machines/…`) via a shared
  `ImageUploadField` component and `src/lib/storage.ts` helper. Public read so
  `<img src>` works without signed URLs; uploads restricted to staff by RLS.
- Permissions reuse the existing SECURITY DEFINER helpers
  (`is_staff()`, `is_manager_or_owner()`) from migration `00016`.
- Typecheck passes (`tsc --noEmit`, exit 0). No dependencies added.

See `docs/SUPABASE-TRANSFER.md` for moving the project from the personal
Supabase account to the business account (separate from this PR).